### PR TITLE
Add bash script for easily creating new shortcuts from the terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ My own lil URL shortener
 
 Clicking this button will clone the repo and deploy it to Netlify, be sure to rename your repo afterwards!
 
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/shaneosullivan/shos.run&utm_source=github&utm_medium=shortener-cs&utm_campaign=devex)
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/cassidoo/cass.run&utm_source=github&utm_medium=shortener-cs&utm_campaign=devex)

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ My own lil URL shortener
 
 Clicking this button will clone the repo and deploy it to Netlify, be sure to rename your repo afterwards!
 
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/shaneosullivan/sos.run&utm_source=github&utm_medium=shortener-cs&utm_campaign=devex)
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/shaneosullivan/shos.run&utm_source=github&utm_medium=shortener-cs&utm_campaign=devex)

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ My own lil URL shortener
 
 Clicking this button will clone the repo and deploy it to Netlify, be sure to rename your repo afterwards!
 
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/cassidoo/cass.run&utm_source=github&utm_medium=shortener-cs&utm_campaign=devex)
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/shaneosullivan/sos.run&utm_source=github&utm_medium=shortener-cs&utm_campaign=devex)

--- a/shorten.sh
+++ b/shorten.sh
@@ -36,7 +36,7 @@ lenFunc() {
   echo ${#1}
 }
 
-# We need to folder of the script, not the pwd. This lets us
+# We need the folder of the script, not the pwd. This lets us
 # execute this script using an alias, from any directory.
 ScriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 

--- a/shorten.sh
+++ b/shorten.sh
@@ -1,0 +1,92 @@
+# Simple script that makes adding a new shortcut trivial from the
+# command line. Simply type:
+#   shorten.sh foo https://bar.com 
+# and a shortcut from https://yourdomain.com/foo to https://bar.com will be added
+#
+# Note that this also commits and pushes to your personal repo using git.
+#
+# For added convenience, you can add an alias to this script to your .bash_profile,
+# e.g.
+#   function short() {
+#     ~/code/cass.run/shorten.sh $1 $2
+#   }
+#
+# Then run it from any folder like
+#   short goo https://google.com
+
+if [ -z "$1" ]
+  then
+    echo "You must provide the shortcode as the first argument"
+    exit 1
+fi
+
+if [ -z "$2" ]
+  then
+    echo "You must provide the full URL as the second argument"
+    exit 1
+fi
+
+if ! [[ $2 =~ https?://.* ]]; then
+  echo "Invalid URL $2"
+  exit 1
+fi
+
+
+lenFunc() {
+  echo ${#1}
+}
+
+# We need to folder of the script, not the pwd. This lets us
+# execute this script using an alias, from any directory.
+ScriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+ArgLen=$(lenFunc $1)
+
+NewLine="/$1"
+
+# 15 is a magic number, the number of spaces that Cassidy chose for her
+# _redirects file to keep it neat and tidy.
+Count=$((15-$ArgLen))
+i=0
+
+# Build the string with spaces until we've used up 15 characters.
+while [ $i -ne $Count ]
+do
+  i=$(($i+1))
+  NewLine=$NewLine" "
+done
+
+# Append the URL
+NewLine=$NewLine"$2"
+
+SourceFile="$ScriptDir/_redirects"
+TmpFile="$ScriptDir/tmpRedirects"
+
+# Ensure we are not adding a shortcut that's already taken
+if grep -q "/$1 " "$SourceFile"; then
+  echo "Error: the shortcut /$1 already exists"
+  exit 1
+fi
+
+# Ensure we're not adding a second shortcut for the same url
+# Note the $ after $2, this ensures that the URL matches only
+# the end of the line, so "google.com" will not match "google.com/foo" 
+if grep -q "$2$" "$SourceFile"; then
+  echo "Error: a shortcut for the url $2 already exists"
+  exit 1
+fi
+
+# Add the line at the top of the file. This avoids messing with the
+# fallback url
+{ echo "$NewLine"; cat $SourceFile; } > $TmpFile
+
+mv $TmpFile $SourceFile 
+
+# Push to whatever branch you are on
+(cd $ScriptDir \
+  && git add $SourceFile \
+  && git commit -am "Add a new shortcut for $1 to $2" \
+  && git branch | grep "*" | sed 's/* //g' | xargs git push origin
+)
+
+echo "Added the shortcut '/$1' pointing to '$2'"


### PR DESCRIPTION
I love your wonderfully simple repo for deploying a personal url shortener!  One thing I'd love to have is a very simple way to add a new shortcut with a single command in the terminal.  This script does just that.

You invoke it like 

`./shorten.sh foo https://google.com`

then the script adds a line to the `_redirects` file, commits the change and pushes it to your personal repo.

Of course, you can alias the script for use anywhere in the terminal, and there's a comment in the file to describe how to do this too.

I hope you find this useful.

